### PR TITLE
Bugfix - remove go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/allienx/myip
-
-go 1.14


### PR DESCRIPTION
Fixes build error:

```
[Error: ENOENT: no such file or directory, open '/tmp/538d111a/src/lambda/main__mod__.go']
```